### PR TITLE
Update licenses, maven url, and add mod support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ minecraft {
 
 repositories {
     maven {
-        url "http://dvs1.progwml6.com/files/maven"
+        url "https://dvs1.progwml6.com/files/maven"
     }
     flatDir {
         dirs 'run/mods'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 apply plugin: "net.minecrell.licenser"
 
-version = '4.0.0-BETA'
+version = '5.0.0-BETA'
 group = 'craftedMods.jeiLotr' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'jeilotr'
 

--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,7 @@ repositories {
     }
     flatDir {
         dirs 'run/mods'
+        dirs 'libs'
     }
 }
 
@@ -108,13 +109,11 @@ dependencies {
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
     minecraft 'net.minecraftforge:forge:1.16.5-36.2.20'
-    
-    compileOnly fg.deobf("mezz.jei:jei-${jei_mc_version}:${jei_version}")
 
-    runtimeOnly fg.deobf("mezz.jei:jei-${jei_mc_version}:${jei_version}")
+    implementation fg.deobf("mezz.jei:jei-${jei_mc_version}:${jei_version}")
     
-    compileOnly fg.deobf(project.dependencies.create("foobar:lotr:${lotr_version}"))
-    runtimeOnly fg.deobf(project.dependencies.create("foobar:lotr:${lotr_version}"))
+    implementation fg.deobf("lotr:lotr-1.16-renewed:5.5")
+    //implementation fg.deobf(project.dependencies.create("foobar:lotr:${lotr_version}"))
 }
 
 // Example for how to get properties into the manifest for reading by the runtime..

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,5 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 jei_mc_version=1.16.5
-jei_version=7.7.1.152
+jei_version=7.7.1.153
 lotr_version=5.5

--- a/src/main/java/craftedMods/jeiLotr/AlloyForge.java
+++ b/src/main/java/craftedMods/jeiLotr/AlloyForge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 CraftedMods (see http://github.com/CraftedMods)
+ * Copyright (C) 2020-2024 CraftedMods (see http://github.com/CraftedMods)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/craftedMods/jeiLotr/FactionCraftingTable.java
+++ b/src/main/java/craftedMods/jeiLotr/FactionCraftingTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 CraftedMods (see http://github.com/CraftedMods)
+ * Copyright (C) 2020-2024 CraftedMods (see http://github.com/CraftedMods)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/craftedMods/jeiLotr/JEILotr.java
+++ b/src/main/java/craftedMods/jeiLotr/JEILotr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 CraftedMods (see http://github.com/CraftedMods)
+ * Copyright (C) 2020-2024 CraftedMods (see http://github.com/CraftedMods)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/craftedMods/jeiLotr/JEIPlugin.java
+++ b/src/main/java/craftedMods/jeiLotr/JEIPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 CraftedMods (see http://github.com/CraftedMods)
+ * Copyright (C) 2020-2024 CraftedMods (see http://github.com/CraftedMods)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/craftedMods/jeiLotr/JEIPlugin.java
+++ b/src/main/java/craftedMods/jeiLotr/JEIPlugin.java
@@ -108,6 +108,12 @@ public class JEIPlugin implements IModPlugin
                     "lotrfa");
             }
 
+            if (ModList.get ().isLoaded ("lotrextended"))
+            {
+                scanFields ("lotr.common.init.ExtendedRecipes", LOTRContainers.class.getName(),
+                    "lotr");
+            }
+
             LOTRAlloyForge dwarvenForgeDevice = new LOTRAlloyForge (new ResourceLocation ("lotr", "dwarven_forge"),
                 new ItemStack (LOTRBlocks.DWARVEN_FORGE.get ()), Arrays.asList (IRecipeType.SMELTING,
                     LOTRRecipes.DWARVEN_FORGE, LOTRRecipes.ALLOY_FORGE, LOTRRecipes.DWARVEN_FORGE_ALLOY),

--- a/src/main/java/craftedMods/jeiLotr/Keg.java
+++ b/src/main/java/craftedMods/jeiLotr/Keg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 CraftedMods (see http://github.com/CraftedMods)
+ * Copyright (C) 2020-2024 CraftedMods (see http://github.com/CraftedMods)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -4,7 +4,7 @@ issueTrackerURL="http:/github.com/CraftedMods/jei-lotr/issues"
 license="GNU GENERAL PUBLIC LICENSE Version 3" 
 [[mods]] 
 modId="jeilotr" 
-version="3.0.0-BETA" 
+version="4.0.0-BETA" 
 displayName="JEI LOTR" 
 updateJSONURL="https://raw.githubusercontent.com/CraftedMods/jei-lotr/master/versions.json" 
 displayURL="http://github.com/CraftedMods/jei-lotr" 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -4,7 +4,7 @@ issueTrackerURL="http:/github.com/CraftedMods/jei-lotr/issues"
 license="GNU GENERAL PUBLIC LICENSE Version 3" 
 [[mods]] 
 modId="jeilotr" 
-version="4.0.0-BETA" 
+version=5.0.0-BETA" 
 displayName="JEI LOTR" 
 updateJSONURL="https://raw.githubusercontent.com/CraftedMods/jei-lotr/master/versions.json" 
 displayURL="http://github.com/CraftedMods/jei-lotr" 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -4,7 +4,7 @@ issueTrackerURL="http:/github.com/CraftedMods/jei-lotr/issues"
 license="GNU GENERAL PUBLIC LICENSE Version 3" 
 [[mods]] 
 modId="jeilotr" 
-version=5.0.0-BETA" 
+version="5.0.0-BETA" 
 displayName="JEI LOTR" 
 updateJSONURL="https://raw.githubusercontent.com/CraftedMods/jei-lotr/master/versions.json" 
 displayURL="http://github.com/CraftedMods/jei-lotr" 

--- a/versions.json
+++ b/versions.json
@@ -4,7 +4,7 @@
 		"2.0.0-BETA": "Updated to LOTR Renewed-3.0",
 		"3.0.0-BETA": "Updated to LOTR Renewed-4.5",
 		"4.0.0-BETA": "Updated to LOTR Renewed-5.5"
-   "5.0.0-BETA": "Added LOTR Renewed Extended support"
+		"5.0.0-BETA": "Added LOTR Renewed Extended support"
 	},
 	"1.15.2": {
 		"1.0.0-ALPHA": "First release for LOTR Renewed-1.0",

--- a/versions.json
+++ b/versions.json
@@ -4,6 +4,7 @@
 		"2.0.0-BETA": "Updated to LOTR Renewed-3.0",
 		"3.0.0-BETA": "Updated to LOTR Renewed-4.5",
 		"4.0.0-BETA": "Updated to LOTR Renewed-5.5"
+   "5.0.0-BETA": "Added LOTR Renewed Extended support"
 	},
 	"1.15.2": {
 		"1.0.0-ALPHA": "First release for LOTR Renewed-1.0",
@@ -16,7 +17,7 @@
 	"promos": {
 		"1.15.2-latest": "1.3.1-BETA",
 		"1.15.2-recommended": "1.3.1-BETA",
-		"1.16.5-latest": "4.0.0-BETA",
-		"1.16.5-recommended": "4.0.0-BETA"
+		"1.16.5-latest": "5.0.0-BETA",
+		"1.16.5-recommended": "5.0.0-BETA"
 	}
 }


### PR DESCRIPTION
Done:

- Updated the licenses since the gradle task would not build
- Fixed the jei maven url, since forge/gradle blocks http in modern build enviroments
- Added support for [Lotr Renewed Extended](https://legacy.curseforge.com/minecraft/mc-mods/lotr-renewed-extended) crafting tables
- Fixes incorrect version #2 

Didn't do:

- I didn't update the CHANGELOG.md 